### PR TITLE
support passing kwargs to constructor dataclasses

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -91,6 +91,17 @@ pip install adt-decorators
               case KeyPress(key, mods): ... # <-- As promised: no `Event.KeyPress`!
   ```
 
+- **Constructor dataclass can have additional keywords arguments passed**
+  ```python
+  @adt(frozen=True)  # <-- Makes `Event.` prefixes optional for constructors.
+  class Event:
+      MouseClick: [int, int]
+      KeyPress:   {'key': str, 'modifiers': list[str]}
+      
+  event = Event.MouseClick(5, 10)
+  event._0 = 42 # Error! Constructor dataclass is frozen. 
+  ```
+
 - **Reflection.**
   The decorated class has a static field `constructors: dict[str, type]`
   which maps the constructor names to their classes, e.g.


### PR DESCRIPTION
let the @adt decorator accept additional `**kwargs` that are passed to the `@dataclass` decorator invoked when building the dataclasses representing constructors.

example:
```python
@adt(frozen=True)
class Expr:
    Var: str                           # Single Unnamed Con Arg
    Abs: [str, 'Expr']                 # Multiple Unnamed Con Args
    App: {'e1': 'Expr', 'e2': 'Expr'}  # Multiple Named Con Args

var = Expr.Var("x")
var._0 = "y" # error!
```